### PR TITLE
fixed builds stats "creating"/"created" in black now in yellow 

### DIFF
--- a/src/styles/themes/CommonColor.js
+++ b/src/styles/themes/CommonColor.js
@@ -119,6 +119,7 @@ const COMMON_COLOR = () => {
     [PIPELINE.STALLED]: COLOR.darkGrey,
     [PIPELINE.STOPPED]: COLOR.greenLight2,
     [PIPELINE.PAUSED]: COLOR.yellow,
+    creating: COLOR.yellow,
 
     default: COLOR.lightGrey,
   });

--- a/src/utils/stringHelper.js
+++ b/src/utils/stringHelper.js
@@ -30,7 +30,7 @@ export const getColorByName = (
       (acc, char) => char.charCodeAt(0) + ((acc << 5) - acc),
       0
     );
-    return `hsl(${stringUniqueHash % 360}, ${saturation}%, ${lightness}%)`;
+    return `hsl(${((stringUniqueHash % 360) + 360) % 360}, ${saturation}%, ${lightness}%)`;
   }
   return '';
 };


### PR DESCRIPTION
Add color for creating pipeline state and fix HSL color calculation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/simulator/622)
<!-- Reviewable:end -->
